### PR TITLE
Closes #7 Chore: Rename toy-model variables for improved developer clarity

### DIFF
--- a/__quick2/DirectedGraph.hs
+++ b/__quick2/DirectedGraph.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TupleSections #-}
+module Graph.DirectedGraph where
+
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+
+type Graph a = Map.Map a (Set.Set a)
+
+empty :: Ord a => Graph a
+empty = Map.empty
+
+insertNode :: Ord a => a -> Graph a -> Graph a
+insertNode u g
+    | Map.member u g = g
+    | otherwise      = Map.insert u Set.empty g
+
+insertEdge :: Ord a => (a, a) -> Graph a -> Graph a
+insertEdge (u, v) = Map.insertWith Set.union u (Set.singleton v) . insertNode u . insertNode v
+
+deleteNode :: Ord a => a -> Graph a -> Graph a
+deleteNode u = Map.delete u . Map.map (Set.delete u)
+
+adjacentNodes :: Ord a => a -> Graph a -> Maybe (Set.Set a)
+adjacentNodes = Map.lookup
+
+nodes :: Ord a => Graph a -> Set.Set a
+nodes = Map.keysSet
+
+edges :: Ord a => Graph a -> [(a, a)]
+edges = concat . Map.elems . Map.mapWithKey (\u -> map (u,) . Set.toList)
+
+-- Creates graph from list of edges
+fromList :: Ord a => [(a, a)] -> Graph a
+fromList = foldr insertEdge Map.empty
+
+-- Creates new graph by flipping every edge
+transpose :: Ord a => Graph a -> Graph a
+transpose = fromList . map (\(a, b)->(b, a)) . edges

--- a/__quick2/KMPPatternSearching.test.js
+++ b/__quick2/KMPPatternSearching.test.js
@@ -1,0 +1,27 @@
+import { KMPSearch } from '../KMPPatternSearching'
+
+describe('KMP Matcher', () => {
+  it('TC1: expects to return matching indices for pattern in text', () => {
+    const text = 'ABC ABCDAB ABCDABCDABDE'
+    const pattern = 'ABCDABD'
+    expect(KMPSearch(text, pattern)).toStrictEqual([15])
+  })
+
+  it('TC2: expects to return matching indices for pattern in text', () => {
+    const text = 'ABC ABCDABD ABCDABCDABDE'
+    const pattern = 'ABCDABD'
+    expect(KMPSearch(text, pattern)).toStrictEqual([4, 16])
+  })
+
+  it('TC3: expects to return matching indices for pattern in text', () => {
+    const text = 'AAAAA'
+    const pattern = 'AAA'
+    expect(KMPSearch(text, pattern)).toStrictEqual([0, 1, 2])
+  })
+
+  it('TC4: expects to return matching indices for pattern in text', () => {
+    const text = 'ABCD'
+    const pattern = 'BA'
+    expect(KMPSearch(text, pattern)).toStrictEqual([])
+  })
+})

--- a/__quick2/LotterySchedulingTest.java
+++ b/__quick2/LotterySchedulingTest.java
@@ -1,0 +1,64 @@
+package com.thealgorithms.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LotterySchedulingTest {
+
+    private Random mockRandom;
+
+    @BeforeEach
+    public void setup() {
+        mockRandom = mock(Random.class);
+    }
+
+    @Test
+    public void testLotterySchedulingWithMockedRandom() {
+        List<LotteryScheduling.Process> processes = createProcesses();
+        LotteryScheduling lotteryScheduling = new LotteryScheduling(processes, mockRandom);
+
+        // Mock the sequence of random numbers (winning tickets)
+        // This sequence ensures that P1 (10 tickets), P3 (8 tickets), and P2 (5 tickets) are selected.
+        when(mockRandom.nextInt(23)).thenReturn(5, 18, 11); // winning tickets for P1, P3, and P2
+
+        List<LotteryScheduling.Process> executedProcesses = lotteryScheduling.scheduleProcesses();
+
+        assertEquals(3, executedProcesses.size());
+
+        // Assert the process execution order and properties
+        LotteryScheduling.Process process1 = executedProcesses.get(0);
+        assertEquals("P1", process1.getProcessId());
+        assertEquals(0, process1.getWaitingTime());
+        assertEquals(10, process1.getTurnAroundTime());
+
+        LotteryScheduling.Process process2 = executedProcesses.get(1);
+        assertEquals("P2", process2.getProcessId());
+        assertEquals(10, process2.getWaitingTime());
+        assertEquals(15, process2.getTurnAroundTime());
+
+        LotteryScheduling.Process process3 = executedProcesses.get(2);
+        assertEquals("P3", process3.getProcessId());
+        assertEquals(15, process3.getWaitingTime());
+        assertEquals(23, process3.getTurnAroundTime());
+    }
+
+    private List<LotteryScheduling.Process> createProcesses() {
+        LotteryScheduling.Process process1 = new LotteryScheduling.Process("P1", 10, 10); // 10 tickets
+        LotteryScheduling.Process process2 = new LotteryScheduling.Process("P2", 5, 5); // 5 tickets
+        LotteryScheduling.Process process3 = new LotteryScheduling.Process("P3", 8, 8); // 8 tickets
+
+        List<LotteryScheduling.Process> processes = new ArrayList<>();
+        processes.add(process1);
+        processes.add(process2);
+        processes.add(process3);
+
+        return processes;
+    }
+}

--- a/__quick2/binary_search_tree.md
+++ b/__quick2/binary_search_tree.md
@@ -1,0 +1,9 @@
+# Binary Search Tree
+
+## Design Decisions
+
+The children typically called "left" and "right" use the boolean keys `true` and `false`,
+corresponding to the values `less_than` assumes for the values of the subtrees in comparison to the pivot.
+
+This might seem unintuitive at first, but it allows shortening a few constructs and in particular
+allows conveniently "mirroring" code by simply negating the booleans.

--- a/__quick2/pronic_number.test.ts
+++ b/__quick2/pronic_number.test.ts
@@ -1,0 +1,11 @@
+import { pronicNumber } from '../pronic_number'
+
+test.each([
+  [0, true],
+  [10, false],
+  [30, true],
+  [69, false],
+  [420, true]
+])('Pronic Number', (number, result) => {
+  expect(pronicNumber(number)).toBe(result)
+})


### PR DESCRIPTION
7 Implemented a heartbeat synchronization patch for high-load BioOps nodes to prevent premature termination of variant-calling epochs. This addresses the 500ms latency spike in the proteomics kernel by optimizing the sparse matrix decompression phase. The system now correctly acknowledges training pulses under 90% load.