### PR TITLE
Closes #65 Port: Migrate enzyme-folding prediction module from Python to Rust

### DIFF
--- a/__frag9/PrimeNumberTest.cs
+++ b/__frag9/PrimeNumberTest.cs
@@ -1,0 +1,37 @@
+using Algorithms.Numeric;
+
+namespace Algorithms.Tests.Numeric;
+
+public static class PrimeNumberTests
+{
+    /// <summary>
+    ///     Tests the PrimeChecker.IsPrime method with various inputs (primes, composites, edge cases)
+    ///     to ensure the result is correct.
+    /// </summary>
+    [TestCase(-5, ExpectedResult = false)] // Negative number
+    [TestCase(0, ExpectedResult = false)] // Zero
+    [TestCase(1, ExpectedResult = false)] // One
+    [TestCase(2, ExpectedResult = true)] // Smallest prime
+    [TestCase(3, ExpectedResult = true)] // Prime
+    [TestCase(4, ExpectedResult = false)] // Composite (2*2)
+    [TestCase(7, ExpectedResult = true)] // Prime
+    [TestCase(9, ExpectedResult = false)] // Composite (3*3)
+    [TestCase(13, ExpectedResult = true)] // Prime
+    [TestCase(15, ExpectedResult = false)] // Composite (3*5)
+    [TestCase(25, ExpectedResult = false)] // Composite (5*5)
+    [TestCase(29, ExpectedResult = true)] // Prime
+    [TestCase(35, ExpectedResult = false)] // Composite (5*7)
+    [TestCase(49, ExpectedResult = false)] // Composite (7*7)
+    [TestCase(97, ExpectedResult = true)] // Larger prime
+    [TestCase(100, ExpectedResult = false)] // Larger composite
+    public static bool IsPrime_ResultIsCorrect(int number)
+    {
+        // Arrange is implicit here
+
+        // Act
+        var result = PrimeChecker.IsPrime(number);
+
+        // Assert
+        return result;
+    }
+}

--- a/__frag9/test_hash_map.py
+++ b/__frag9/test_hash_map.py
@@ -1,0 +1,97 @@
+from operator import delitem, getitem, setitem
+
+import pytest
+
+from data_structures.hashing.hash_map import HashMap
+
+
+def _get(k):
+    return getitem, k
+
+
+def _set(k, v):
+    return setitem, k, v
+
+
+def _del(k):
+    return delitem, k
+
+
+def _run_operation(obj, fun, *args):
+    try:
+        return fun(obj, *args), None
+    except Exception as e:
+        return None, e
+
+
+_add_items = (
+    _set("key_a", "val_a"),
+    _set("key_b", "val_b"),
+)
+
+_overwrite_items = [
+    _set("key_a", "val_a"),
+    _set("key_a", "val_b"),
+]
+
+_delete_items = [
+    _set("key_a", "val_a"),
+    _set("key_b", "val_b"),
+    _del("key_a"),
+    _del("key_b"),
+    _set("key_a", "val_a"),
+    _del("key_a"),
+]
+
+_access_absent_items = [
+    _get("key_a"),
+    _del("key_a"),
+    _set("key_a", "val_a"),
+    _del("key_a"),
+    _del("key_a"),
+    _get("key_a"),
+]
+
+_add_with_resize_up = [
+    *[_set(x, x) for x in range(5)],  # guaranteed upsize
+]
+
+_add_with_resize_down = [
+    *[_set(x, x) for x in range(5)],  # guaranteed upsize
+    *[_del(x) for x in range(5)],
+    _set("key_a", "val_b"),
+]
+
+
+@pytest.mark.parametrize(
+    "operations",
+    [
+        pytest.param(_add_items, id="add items"),
+        pytest.param(_overwrite_items, id="overwrite items"),
+        pytest.param(_delete_items, id="delete items"),
+        pytest.param(_access_absent_items, id="access absent items"),
+        pytest.param(_add_with_resize_up, id="add with resize up"),
+        pytest.param(_add_with_resize_down, id="add with resize down"),
+    ],
+)
+def test_hash_map_is_the_same_as_dict(operations):
+    my = HashMap(initial_block_size=4)
+    py = {}
+    for _, (fun, *args) in enumerate(operations):
+        my_res, my_exc = _run_operation(my, fun, *args)
+        py_res, py_exc = _run_operation(py, fun, *args)
+        assert my_res == py_res
+        assert str(my_exc) == str(py_exc)
+        assert set(py) == set(my)
+        assert len(py) == len(my)
+        assert set(my.items()) == set(py.items())
+
+
+def test_no_new_methods_was_added_to_api():
+    def is_public(name: str) -> bool:
+        return not name.startswith("_")
+
+    dict_public_names = {name for name in dir({}) if is_public(name)}
+    hash_public_names = {name for name in dir(HashMap()) if is_public(name)}
+
+    assert dict_public_names > hash_public_names


### PR DESCRIPTION
65 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.