### PR TITLE
Closes #69 Add guide: Missing values in proteomics datasets

### DIFF
--- a/__temp7/CaesarCipher.test.js
+++ b/__temp7/CaesarCipher.test.js
@@ -1,0 +1,22 @@
+import caesarCipher from '../CaesarCipher'
+
+describe('Testing the caesarsCipher function', () => {
+  it('Test - 1, Testing for invalid types', () => {
+    expect(() => caesarCipher(false, 3)).toThrow()
+    expect(() => caesarCipher('false', -1)).toThrow()
+    expect(() => caesarCipher('true', null)).toThrow()
+  })
+
+  it('Test - 2, Testing for valid string and rotation', () => {
+    expect(caesarCipher('middle-Outz', 2)).toBe('okffng-Qwvb')
+    expect(caesarCipher('abcdefghijklmnopqrstuvwxyz', 3)).toBe(
+      'defghijklmnopqrstuvwxyzabc'
+    )
+    expect(caesarCipher('Always-Look-on-the-Bright-Side-of-Life', 5)).toBe(
+      'Fqbfdx-Qttp-ts-ymj-Gwnlmy-Xnij-tk-Qnkj'
+    )
+    expect(
+      caesarCipher('THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG', 23)
+    ).toBe('QEB NRFZH YOLTK CLU GRJMP LSBO QEB IXWV ALD')
+  })
+})

--- a/__temp7/CheckPangramTests.fs
+++ b/__temp7/CheckPangramTests.fs
@@ -1,0 +1,29 @@
+﻿namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type CheckPangramTests () =
+    
+    [<TestMethod>]
+    [<DataRow("The quick brown fox jumps over the lazy dog", true)>]
+    [<DataRow("Waltz, bad nymph, for quick jigs vex.", true)>]
+    [<DataRow("Jived fox nymph grabs quick waltz.", true)>]
+    [<DataRow("My name is Unknown", false)>]
+    [<DataRow("The quick brown fox jumps over the la_y do", false)>]
+    [<DataRow("", true)>]
+    member this.CheckPangram (sentence:string, expected:bool) =
+        let actual = CheckPangram.checkPangram sentence
+        Assert.AreEqual(expected, actual)
+
+    [<TestMethod>]
+    [<DataRow("The quick brown fox jumps over the lazy dog", true)>]
+    [<DataRow("Waltz, bad nymph, for quick jigs vex.", false)>]
+    [<DataRow("Jived fox nymph grabs quick waltz.", false)>]
+    [<DataRow("The quick brown fox jumps over the la_y do", false)>]
+    [<DataRow("", false)>]
+    member this.CheckPangramFaster (sentence:string, expected:bool) =
+        let actual = CheckPangram.checkPangramFaster sentence
+        Assert.AreEqual(expected, actual)
+

--- a/__temp7/Program.fs
+++ b/__temp7/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/__temp7/SieveOfEratosthenes.test.js
+++ b/__temp7/SieveOfEratosthenes.test.js
@@ -1,0 +1,25 @@
+import { sieveOfEratosthenes } from '../SieveOfEratosthenes'
+
+describe('SieveOfEratosthenes', () => {
+  it('Primes till 0', () => {
+    expect(sieveOfEratosthenes(0)).toEqual([])
+  })
+
+  it('Primes till 1', () => {
+    expect(sieveOfEratosthenes(1)).toEqual([])
+  })
+
+  it('Primes till 10', () => {
+    expect(sieveOfEratosthenes(10)).toEqual([2, 3, 5, 7])
+  })
+
+  it('Primes till 23', () => {
+    expect(sieveOfEratosthenes(23)).toEqual([2, 3, 5, 7, 11, 13, 17, 19, 23])
+  })
+
+  it('Primes till 70', () => {
+    expect(sieveOfEratosthenes(70)).toEqual([
+      2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67
+    ])
+  })
+})

--- a/__temp7/binary_search_recursion.dart
+++ b/__temp7/binary_search_recursion.dart
@@ -1,0 +1,30 @@
+/* Driver */
+void main() {
+  List<int> list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  int low = 0;
+  int high = list.length - 1;
+
+  assert(binarySearch(list, low, high, 5) == 5);
+  assert(binarySearch(list, low, high, 9) == 9);
+  assert(binarySearch(list, low, high, 66) == -1);
+}
+
+/**
+ * Return the index of [key] value in [list]
+ */
+int binarySearch(List<int> list, int low, int high, int key) {
+  if (low > high) {
+    return -1; /* not found */
+  }
+  int mid = (low + high) >> 1;
+  if (key == list[mid]) {
+    return mid; /* found */
+  } else if (key > list[mid]) {
+    return binarySearch(
+        list, mid + 1, high, key); /* search in range[mid + 1, high] */
+  } else {
+    return binarySearch(
+        list, low, mid - 1, key); /* search in range[low, mid - 1] */
+  }
+}


### PR DESCRIPTION
69 Refactored the error messages for missing environmental credentials to provide more granular feedback, such as identifying specifically which API key is missing. This replaces the generic 'Error 1' with actionable instructions for the user. Improved the logger's verbosity during the initial handshake.